### PR TITLE
Make working with Linux more pleasant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.exe
 *.njson
+/gomkbuild.cov
+/ndt
+/web_connectivity

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM openobservatory/mk-alpine
+RUN apk add --no-progress git go

--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,12 @@ Do not use it for anything serious, for the moment.
 
 ## Getting started
 
+Install MaxMind databases using:
+
+```bash
+./script/download-mmdb.sh
+```
+
 ### macOS
 
 Install Measurement Kit using brew:
@@ -68,19 +74,16 @@ It is recommended to _also_ test using a real Windows box.
 
 ### Linux
 
-We have a Docker container. Enter into the container with:
+We have a Docker container. Build the container with:
 
 ```bash
-docker run -it -v `pwd`:/go/src/github.com/measurement-kit/go-measurement-kit  \
-  openobservatory/mk-alpine:20190509
+docker build -t gomkbuild .
 ```
 
-Once in the container, do:
+Enter into the container with:
 
 ```bash
-export GOPATH=/go
-apk add go
-cd /go/src/github.com/measurement-kit/go-measurement-kit
+docker run -it -v`pwd`:/gomkbuild -w/gomkbuild gomkbuild
 ```
 
 Then you're all set. Just `go get -v ./...` as usual.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/measurement-kit/go-measurement-kit
+
+go 1.12

--- a/script/build-alpine.sh
+++ b/script/build-alpine.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-set -ex
-dirname=`dirname $0`
-topdir=`cd $dirname && pwd -P`
-cd $topdir/..
-export GOPATH=/go
-apk add --no-progress git go
-go get -v ./...
-go test -v ./...

--- a/script/build-travis-linux.sh
+++ b/script/build-travis-linux.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -ex
-gorepopath=/go/src/github.com/measurement-kit/go-measurement-kit
-docker run -it -v `pwd`:$gorepopath openobservatory/mk-alpine:20190509         \
-  $gorepopath/script/build-alpine.sh
+docker build -t gomkbuild .
+docker run -it -v`pwd`:/gomkbuild -w/gomkbuild gomkbuild                       \
+  go test -v -coverprofile=gomkbuild.cov ./...


### PR DESCRIPTION
- Use the latest version of the container; closes #12

- Create Dockerfile to avoid always reinstalling Go; closes #13

- Use go.mod to simplify working in container; closes #14

- travis: simplify build by using Dockerfile; closes #15